### PR TITLE
Fixes Warning

### DIFF
--- a/src/Date.php
+++ b/src/Date.php
@@ -114,9 +114,9 @@ class Date extends AbstractDateTime
         return parent::modify($modify)->setTime(0, 0, 0);
     }
 
-    public function setTime($hour, $minute, $second = 0)
+    public function setTime($hour, $minute, $second = 0, $microseconds = 0)
     {
-        return parent::setTime(0, 0, 0);
+        return parent::setTime(0, 0, 0, 0);
     }
 
     public function setTimestamp($timestamp)


### PR DESCRIPTION
`Warning: Declaration of Date::setTime($hour, $minute, $second = 0) should be compatible with DateTimeImmutable::setTime($hour, $minute, $second = NULL, $microseconds = NULL) in /in/qOffV on line 7` (https://3v4l.org/qOffV)

Fehler tritt ab PHP 7.1 auf.